### PR TITLE
Fix text, color fallback, comment; add utils module and tests

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
              </div>
              <div id="human-feedback-section" class="hidden">
                  <h3 class="text-xl font-semibold mb-3 text-yellow-400">Human Feedback Loop</h3>
-                 <p class="text-sm text-gray-400 mb-3">Add a new rule for the AI to remember for all future analyses. This will override its default behavior.</p>
+                 <p class="text-sm text-gray-400 mb-3">Add a new rule for the AI to remember for all future analysis. This will override its default behavior.</p>
                  <textarea id="human-feedback-input" rows="3" class="w-full p-3 bg-gray-700 border border-gray-600 rounded-lg focus:ring-2 focus:ring-yellow-500 transition" placeholder="e.g., 'The logo must always be in the top right corner.'"></textarea>
                  <button id="save-feedback-button" class="mt-3 w-full bg-yellow-600 hover:bg-yellow-700 text-white font-bold py-2 px-4 rounded-lg shadow-lg transition-all">
                      Save & Teach AI
@@ -117,7 +117,8 @@
 </div>
 
 <script type="module">
-    // --- Firebase config (from your project) ---
+    // Firebase configuration
+import { isArabic } from "./src/utils.js";
     const firebaseConfig = {
       apiKey: "AIzaSyCML9hLnQUzwHdWQtVZTkUVdLVta-PNzc",
       authDomain: "qa-app-e7aa9.firebaseapp.com",
@@ -467,7 +468,7 @@ ${mainPrompt || '(No specific request, focus on Core QA Rule)'}
         reportCard.open = true;
         const summary = document.createElement('summary');
         summary.className = 'p-4 cursor-pointer hover:bg-gray-700 flex justify-between items-center';
-        const verdictColor = { 'Approved': 'text-green-400', 'Needs Revision': 'text-yellow-400', 'Rejected': 'text-red-400'}[item.reportData.overallVerdict];
+        const verdictColor = { 'Approved': 'text-green-400', 'Needs Revision': 'text-yellow-400', 'Rejected': 'text-red-400'}[item.reportData.overallVerdict] || 'text-red-400';
         summary.innerHTML = `<h3 class="font-semibold text-lg">${item.assetName}</h3><span class="font-bold text-lg ${verdictColor}">${item.reportData.overallVerdict || 'Error'}</span>`;
         const content = document.createElement('div');
         content.className = 'p-4 border-t border-gray-700';
@@ -483,11 +484,6 @@ ${mainPrompt || '(No specific request, focus on Core QA Rule)'}
             fail: `<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`,
             info: `<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-yellow-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`
         };
-        const isArabic = (text) => {
-            if (!text) return false;
-            const arabicRegex = /[\u0600-\u06FF]/;
-            return arabicRegex.test(text);
-        }
         const pointsHTML = (data.keyPoints || []).map(item => `<div class="flex items-start gap-3 p-3 rounded-md bg-gray-900/70"><div>${icons[item.status] || icons['info']}</div><p class="flex-1 text-gray-300">${item.point}</p></div>`).join('');
         const copyAnalysisHTML = (data.copyAnalysis && data.copyAnalysis.length > 0) ? `
             <div class="pt-4">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ai-asset-qa-tool",
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+export const isArabic = (text) => {
+    if (!text) return false;
+    const arabicRegex = /[\u0600-\u06FF]/;
+    return arabicRegex.test(text);
+};

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,15 @@
+import { isArabic } from '../src/utils.js';
+
+describe('isArabic', () => {
+  test('returns true for Arabic text', () => {
+    expect(isArabic('مرحبا')).toBe(true);
+  });
+
+  test('returns false for Latin text', () => {
+    expect(isArabic('Hello')).toBe(false);
+  });
+
+  test('returns false for empty string', () => {
+    expect(isArabic('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- correct grammar in feedback instructions
- clarify Firebase configuration comment
- use default style for missing verdict color
- extract `isArabic` helper into new module
- add Jest test for helper and npm test script

## Testing
- `npm test` *(fails: Cannot find module 'node_modules/jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_68657e92f1f0832289d568ecce959b39