### PR TITLE
Externalize firebase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+firebaseConfig.js

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# AI-Powered Asset QA Tool
+
+This project is a simple web-based tool for analyzing assets using Firebase for storage and Firestore. The Firebase configuration is loaded from an external JavaScript file so that sensitive project keys are not committed to the repository.
+
+## Configuration
+
+1. Duplicate `firebaseConfig.example.js` and rename the copy to `firebaseConfig.js`.
+2. Fill in your Firebase project credentials in `firebaseConfig.js`.
+3. Deploy the `index.html` file along with the new `firebaseConfig.js` to your hosting environment.
+
+The `firebaseConfig.js` file is ignored by Git to prevent accidental commits of private keys.

--- a/firebaseConfig.example.js
+++ b/firebaseConfig.example.js
@@ -1,0 +1,8 @@
+export const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};

--- a/index.html
+++ b/index.html
@@ -140,15 +140,8 @@
 </div>
 
 <script type="module">
-    // --- Firebase config (from your project) ---
-    const firebaseConfig = {
-      apiKey: "AIzaSyCML9hLnQUzwHdWQtVZTkUVdLVta-PNzc",
-      authDomain: "qa-app-e7aa9.firebaseapp.com",
-      projectId: "qa-app-e7aa9",
-      storageBucket: "qa-app-e7aa9.appspot.com",
-      messagingSenderId: "994184038269",
-      appId: "1:994184038269:web:492bd15c26454c05142e14"
-    };
+    // --- Firebase config is loaded from an external file ---
+    import { firebaseConfig } from './firebaseConfig.js';
     firebase.initializeApp(firebaseConfig);
     const db = firebase.firestore();
 


### PR DESCRIPTION
## Summary
- load firebase configuration from a separate `firebaseConfig.js` module
- add `.gitignore` entry to keep real config out of version control
- document how to provide your own firebase credentials
- provide `firebaseConfig.example.js` as a template

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686b864ea2a48322b154347b1add1123