### PR TITLE
Add secure key handling guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,11 @@ This project is a simple web-based tool for analyzing assets using Firebase for 
 3. Deploy the `index.html` file along with the new `firebaseConfig.js` to your hosting environment.
 
 The `firebaseConfig.js` file is ignored by Git to prevent accidental commits of private keys.
+
+## Security Considerations
+
+Storing API or Firebase keys in the browser exposes them to anyone with access to the site's JavaScript. Malicious users could view the keys in developer tools and abuse your Firebase project or API quotas. For production deployments, avoid embedding these secrets directly in `localStorage` or in a public JavaScript file.
+
+Instead, run a small server-side proxy that holds the credentials in environment variables and forwards requests to the Gemini API or Firebase. The frontend can then call your proxy endpoint without ever seeing the real keys. Another option is to inject configuration on the server during deployment rather than storing it in the browser.
+
+When the application loads, it first checks `localStorage` for a saved key. If none is found, it attempts to retrieve one from `/api/api-key`. You can implement this endpoint in your backend to return the key securely.

--- a/index.html
+++ b/index.html
@@ -218,6 +218,22 @@
     function getApiKey() {
         return window.localStorage.getItem('GEMINI_API_KEY') || '';
     }
+    async function fetchApiKeyFromServer() {
+        try {
+            const res = await fetch('/api/api-key');
+            if (res.ok) {
+                const data = await res.json();
+                if (data && data.key) {
+                    setApiKey(data.key);
+                    apiKeyInput.value = data.key;
+                    return data.key;
+                }
+            }
+        } catch (err) {
+            console.log('Unable to fetch API key from server:', err);
+        }
+        return null;
+    }
     saveApiKeyBtn.onclick = () => {
         setApiKey(apiKeyInput.value.trim());
         apiKeyStatus.classList.remove('hidden');
@@ -843,6 +859,7 @@ ${mainPrompt || '(No specific request, focus on Core QA Rule)'}
 
     // --- Init, event handlers, first render ---
     document.addEventListener('DOMContentLoaded', async () => {
+        if (!getApiKey()) await fetchApiKeyFromServer();
         await renderFeedbackList();
         await renderHistoryList();
         historySearchInput.addEventListener('input', (e) => renderHistoryList(e.target.value.trim()));


### PR DESCRIPTION
## Summary
- warn about browser key storage and offer server-side proxy guidance
- allow optional retrieval of API key from backend

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686bc8195c4c8322a66066b4038da45f